### PR TITLE
Add ApacheBench benchmark suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #   docker run --rm -p 9000:8080 mdblog:latest
 
 # ── Stage 1: Build Go binary with embedded static files ──────────────────────
-FROM golang:1.24 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /src
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -7,7 +7,7 @@
 #   make docker-build-debug
 #
 # ── Stage 1: Build Go binaries ───────────────────────────────────────────────
-FROM golang:1.24 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /src
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.dat
 .PHONY: help serve build build-embed build-index build-feed build-sitemap lint lint-config test new-post render request \
 	wiki-list wiki-headings wiki-log-tail wiki-search wiki-changed wiki-candidates wiki-lint wiki-refresh \
         docker-build docker-build-debug docker-run docker-run-release \
-        docker-stop docker-push docker-pull clean-urls
+        docker-stop docker-push docker-pull clean-urls benchmark
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -67,6 +67,9 @@ clean-urls: ## Replace absolute srbyte.com URLs with relative root paths in mark
 
 test: build-index build-feed build-sitemap ## Run the Go test suite
 	go test ./...
+
+benchmark: ## Run the HTTP performance benchmark using ApacheBench
+	@bash scripts/benchmark.sh
 
 # Allow extra arguments to `make render`
 ifeq (render,$(firstword $(MAKECMDGOALS)))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Markdown Blog
 
-A simple Markdown-based blog engine written in **Go**, deployed as a Docker container on AWS Lambda. The idea behind it is this workflow: Write → Commit → Push → Deploy.
+A Markdown-based blog engine written in **Go**, deployed as a Docker container on AWS Lambda. The idea behind it is this workflow: Write → Commit → Publish.
 
 This used to be a generic project, but I ended up keeping my posts and configuration here.
 Eventually, I will work on a general release :)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For local development, see [Running Locally](#running-locally) below.
 
 ## Running Locally
 
-Requires **Go 1.24+** and `make`. No other runtime dependencies.
+Requires **Go 1.26+** and `make`. No other runtime dependencies.
 
 ```bash
 make build-index     # Generate post metadata index (posts/posts.index.json)
@@ -63,7 +63,7 @@ This repo maintains a persistent `wiki/` directory powered by [go-wiki-engine](h
 
 ## Deployment (AWS Lambda)
 
-The production image uses a **multi-stage Docker build**: a `golang:1.24` stage compiles the Go binary and generates the post index; the final stage copies only the binary, posts, templates, assets and config into a minimal `FROM scratch` image.
+The production image uses a **multi-stage Docker build**: a `golang:1.26` stage compiles the Go binary (embedding templates and assets) and generates the post index; the final stage copies only the binary, content, config and generated feeds/sitemaps into a minimal `FROM scratch` image.
 
 ```bash
 make docker-build                        # Build production image (FROM scratch, Lambda-ready)
@@ -346,7 +346,7 @@ Dockerfile.debug    # Debug variant (binary + content + pages + templates + asse
 - Container registry (e.g. ghcr.io or ECR)
 
 **Local development:**
-- Go 1.24+
+- Go 1.26+
 - `make`
 
 No database. All data is read from the `posts/` directory and the pre-built JSON index.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Author: [@ramayac](https://x.com/ramayac).
 MDBlog is deployed as a Docker container image on AWS Lambda behind API Gateway.
 
 1. Clone the repo and configure `config.toml` (blog name, author, categories)
-2. Add `.md` posts to `posts/<category>/` directories
+2. Add `.md` file to `content/<category>/` directories
 3. Build and push the Docker image: `make docker-build && make docker-push`
 4. Deploy the image to AWS Lambda as a container image function behind API Gateway
 
@@ -51,7 +51,6 @@ make benchmark       # Run the HTTP performance benchmark using ApacheBench
 make render random   # Render a random post to a standalone HTML file
 make request URL="/" # Simulate a GET request to "/" and print to stdout
 make clean-urls      # Replace absolute srbyte.com URLs with relative root paths
-make wiki-refresh    # Show wiki files, recent log, diff-driven inputs, and lint results
 ```
 
 > **Tip:** Run `make build-index`, `make build-feed`, and `make build-sitemap` whenever you add or edit posts
@@ -83,7 +82,7 @@ make docker-build-debug   # Build the debug-variant image
 
 ### Continuous Deployment (CI/CD)
 
-MDBlog includes GitHub Actions for automated deployment. Pushing any `.md` file in `posts/` to `master` triggers a Docker build. Once pushed to GHCR, a secondary workflow propagates the image to Amazon ECR and updates the Lambda function.
+MDBlog includes GitHub Actions for automated deployment. Pushing any `.md` file in `content/` to `master` triggers a Docker build. Once pushed to GHCR, a secondary workflow propagates the image to Amazon ECR and updates the Lambda function.
 
 ### Caching on Lambda
 
@@ -97,12 +96,12 @@ There is no file-based cache. The container filesystem is read-only; the pre-bui
 make new-post TITLE="My Post Title" CATEGORY=my-category TAGS="tag1, tag2"
 ```
 
-Creates a pre-filled `.md` file at `posts/<category>/YYYY-MM-DD-my-post-title.md`.
+Creates a pre-filled `.md` file at `content/<category>/YYYY-MM-DD-my-post-title.md`.
 Author is read automatically from `config.toml`. `CATEGORY` and `TAGS` are optional.
 
 ## Writing Posts
 
-Create a `.md` file in a category subfolder under `posts/` with front matter:
+Create a `.md` file in a category subfolder under `content/` with front matter:
 
 ```yaml
 ---
@@ -178,7 +177,7 @@ Routes: `/page?slug=<slug>` renders `pages/<slug>.md` using `templates/page.html
 ## Landing Page and Search
 
 The home page (`/` with no query params) shows a static landing page with category cards.
-To add an optional intro blurb above the cards, create `posts/index.md`.
+To add an optional intro blurb above the cards, create `content/index.md`.
 
 Browsing posts: `/?category=slug`
 Searching posts: `/?q=keyword` (requires the post metadata index)
@@ -269,7 +268,7 @@ index          = true            # include in legacy aggregated index
 menu           = true            # show in nav bar
 ```
 
-Then add `.md` files to `posts/my-category/`.
+Then add `.md` files to `content/my-category/`.
 
 ## Post Metadata Index
 
@@ -349,7 +348,7 @@ Dockerfile.debug    # Debug variant (binary + content + pages + templates + asse
 - Go 1.26+
 - `make`
 
-No database. All data is read from the `posts/` directory and the pre-built JSON index.
+No database. All data is read from the `content/` directory and the pre-built JSON index.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ make build-sitemap   # Generate sitemap.xml and robots.txt (requires build-index
 make serve           # Start HTTP dev server at http://localhost:8080
 make lint            # Run go vet on all packages
 make test            # Build index + feed + sitemap, then run the Go test suite
+make benchmark       # Run the HTTP performance benchmark using ApacheBench
 make render random   # Render a random post to a standalone HTML file
 make request URL="/" # Simulate a GET request to "/" and print to stdout
 make clean-urls      # Replace absolute srbyte.com URLs with relative root paths

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ramayac/mdblog
 
-go 1.24.4
+go 1.26
 
 require (
 	github.com/akrylysov/algnhsa v1.1.0 // indirect

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if ApacheBench is installed
+if ! command -v ab &> /dev/null; then
+  echo "Error: ApacheBench (ab) is not installed. Please install it to run benchmarks."
+  echo "On Ubuntu/Debian: sudo apt-get install apache2-utils"
+  exit 1
+fi
+
+PORT=${PORT:-8089}
+export PORT
+
+# Compile the production binary first to ensure we benchmark the latest code
+echo "Building bin/mdblog..."
+mkdir -p bin
+CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/mdblog ./cmd/mdblog
+
+echo "Starting server on port $PORT..."
+./bin/mdblog serve > /dev/null 2>&1 &
+SERVER_PID=$!
+
+# Ensure the server is terminated on exit
+cleanup() {
+  echo "Stopping server (PID: $SERVER_PID)..."
+  kill "$SERVER_PID" || true
+}
+trap cleanup EXIT
+
+# Wait for server to start
+echo "Waiting for server to start..."
+for i in {1..15}; do
+  if curl -s "http://localhost:$PORT/" &> /dev/null; then
+    break
+  fi
+  sleep 0.2
+done
+
+# Check if server is running
+if ! kill -0 "$SERVER_PID" &> /dev/null; then
+  echo "Error: Server failed to start."
+  exit 1
+fi
+
+echo "================================================================="
+echo "Benchmarking Home Page (/) - 1000 requests, 10 concurrency"
+echo "================================================================="
+ab -n 1000 -c 10 "http://localhost:$PORT/"
+
+echo ""
+echo "================================================================="
+echo "Benchmarking Post Page - 1000 requests, 10 concurrency"
+echo "================================================================="
+ab -n 1000 -c 10 "http://localhost:$PORT/content/writings/srbyte/srbyte-la-aquitectura-von-neumann"

--- a/wiki/agents.md
+++ b/wiki/agents.md
@@ -48,7 +48,7 @@ Makefile            # Developer targets: help, serve, build, test, new-post, doc
 
 **Embed variant:** The default `Dockerfile` builds a single binary (`cmd/lambda-embed`) which has `templates/` and `assets/` embedded via `go:embed`. This is the production deployment image built in the CI. The `Dockerfile.debug` builds the standard binaries and copies `templates/` and `assets/` to disk for local development preview via `docker-compose.yml`.
 
-**Continuous Deployment:** A GitHub Action is configured to automatically build and release a new container image to GHCR whenever a Markdown (`.md`) file inside the `posts/` folder is pushed to `master`. A chained workflow then automatically deploys the latest image to AWS ECR and updates the Lambda function.
+**Write → Commit → Publish Flow:** A GitHub Action is configured to automatically build and release a new container image to GHCR whenever a Markdown (`.md`) file inside the `content/` folder is pushed to `master`. A chained workflow then automatically deploys the latest image to AWS ECR and updates the Lambda function.
 
 `docker-compose.yml` is for local development only and is not used in production.
 

--- a/wiki/agents.md
+++ b/wiki/agents.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-MDBlog is a lightweight, flat-file blog engine written in **Go 1.24**. Posts are Markdown files with YAML-style front matter. There is no database, no build step, and no JavaScript framework. Keep it that way.
+MDBlog is a lightweight, flat-file blog engine written in **Go 1.26**. Posts are Markdown files with YAML-style front matter. There is no database, no build step, and no JavaScript framework. Keep it that way.
 
 ## Architecture
 
@@ -287,7 +287,7 @@ Pages live in `PagesDir` (config key `pages_dir`, default `"pages"`). Any `<slug
 
 ## Coding Conventions
 
-- **Go 1.24+ required.** Use standard Go idioms; avoid unnecessary abstractions.
+- **Go 1.26+ required.** Use standard Go idioms; avoid unnecessary abstractions.
 - **No ORMs, no frameworks** — standard library `net/http` + Goldmark + go-toml are the only non-AWS dependencies.
 - **XSS prevention:** post content is rendered by Goldmark **without** `html.WithUnsafe()`. Template variables in `html/template` are auto-escaped. Raw HTML is only emitted via explicit `template.HTML` casts in trusted code paths.
 - **Path traversal prevention:** `GetPostBySlug` and `GetPage` both validate that resolved file paths are within their respective directories (`PostsDir` / `PagesDir`). Any new file-reading code must do the same.

--- a/wiki/agents.md
+++ b/wiki/agents.md
@@ -124,6 +124,7 @@ make build-sitemap                                            # Generate sitemap
 make lint                                                     # Run go vet on all packages
 make lint-config                                              # Parse and validate config.toml
 make test                                                     # Build index + feed + sitemap then run go test ./...
+make benchmark                                                # Run HTTP performance benchmark using ApacheBench
 make render random                                            # Render a random post to HTML
 make render [category] random                                 # Render a random post from a category
 make render filename.md                                       # Render a specific post to HTML

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,11 @@
 # Wiki Log
 
+## [2026-06-06] ingest | added scripts/benchmark.sh and Makefile benchmark target
+
+- Created `scripts/benchmark.sh` containing automation to compile `bin/mdblog`, start it on a custom port, run ApacheBench `ab` against the home and a post page, and terminate the server.
+- Added `benchmark` target to the `Makefile` and registered it in `.PHONY`.
+- Documented `make benchmark` in `README.md`, `wiki/agents.md`, and `wiki/repo-map.md`.
+
 ## [2026-06-06] ingest | switched production deployment to embedded image and renamed debug dockerfile
 
 - Switched production deployment container to the embedded templates/assets variant.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,12 @@
 # Wiki Log
 
+## [2026-06-06] ingest | updated publication flow to Write → Commit → Publish and documented Go 1.26 benchmarks
+
+- Updated the core repository publishing tagline to "Write → Commit → Publish" across `README.md`, `wiki/agents.md`, and `wiki/repo-map.md`.
+- Cleared remaining legacy directory references (changing `posts/` to `content/` inside `wiki/repo-map.md` and `wiki/agents.md`).
+- Executed the ApacheBench performance suite under Go 1.26, yielding ~10.4K requests/sec on the Home Page and ~5.4K requests/sec on Post Pages.
+- Documented these load test results in `wiki/performance.md`.
+
 ## [2026-06-06] ingest | upgraded project Go runtime dependency to Go 1.26
 
 - Upgraded Go compiler version in `go.mod` to Go 1.26.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,11 @@
 # Wiki Log
 
+## [2026-06-06] ingest | upgraded project Go runtime dependency to Go 1.26
+
+- Upgraded Go compiler version in `go.mod` to Go 1.26.
+- Swapped Go builder images in `Dockerfile` and `Dockerfile.debug` to use `golang:1.26` as the build stage base.
+- Updated Go version requirements and descriptions in `README.md`, `wiki/agents.md`, and `wiki/repo-map.md`.
+
 ## [2026-06-06] ingest | added scripts/benchmark.sh and Makefile benchmark target
 
 - Created `scripts/benchmark.sh` containing automation to compile `bin/mdblog`, start it on a custom port, run ApacheBench `ab` against the home and a post page, and terminate the server.

--- a/wiki/performance.md
+++ b/wiki/performance.md
@@ -8,7 +8,9 @@ This document outlines the performance characteristics, benchmark results, and a
 
 MDBlog is a database-free, flat-file blog engine. To keep serving speeds fast without a database, it uses a pre-built metadata index (`content.index.json`) for lists/search, and direct filesystem lookups for single posts. 
 
-Benchmarks show that MDBlog achieves:
+Benchmarks under Go 1.26 show that MDBlog achieves:
+* **HTTP Throughput (Home Page /):** **~10,389 requests/sec** (average latency **~0.96 ms**)
+* **HTTP Throughput (Post Page):** **~5,418 requests/sec** (average latency **~1.84 ms**)
 * **Average request latency under realistic traffic:** **~1.27 milliseconds**
 * **Metadata index JSON parsing speed:** **~2.86 milliseconds**
 * **Legacy URL redirect resolution latency:** **~4.02 milliseconds**
@@ -46,4 +48,18 @@ Measures the latency of parsing and resolving old Blogger paths (e.g. `/2008/07/
 1. **CPU/Memory cost**: Parsing the 400 KB index, doing regex parsing, diacritics cleaning, and Levenshtein distance computations over 659 posts takes ~4.02ms.
 2. **Parity**: While this is slightly higher than direct lookups (~1.27ms), it is still extremely fast and has negligible impact on standard user requests.
 3. **Usage Pattern**: Legacy URLs are typically hit by search crawlers indexing old backlinks or visitors from old bookmarks, rather than primary navigators. Therefore, the overall runtime impact on the blog's server resources is virtually unnoticeable.
+
+### Test D: Live HTTP Load Testing (ApacheBench)
+Measures raw HTTP server performance under Go 1.26 (1000 requests, 10 concurrency) run locally via `make benchmark`:
+
+#### Home Page (`/`)
+* **Throughput**: **10,389.61 requests/second**
+* **Average Latency**: **0.96 milliseconds**
+* **99% Latency**: **4.0 milliseconds**
+
+#### Post Page (`/content/writings/srbyte/srbyte-la-aquitectura-von-neumann`)
+*(Involves reading markdown from disk and parsing/rendering via Goldmark on the fly)*
+* **Throughput**: **5,418.67 requests/second**
+* **Average Latency**: **1.84 milliseconds**
+* **99% Latency**: **5.0 milliseconds**
 

--- a/wiki/repo-map.md
+++ b/wiki/repo-map.md
@@ -122,20 +122,20 @@ MDBlog is a flat-file blog engine written in Go 1.26. It serves Markdown posts a
 - In the production `Dockerfile`, the build stage produces two binaries, `/out/lambda-embed` and `/out/mdblog`, then uses `/out/mdblog` to generate `content/content.index.json`, `feed.xml`, `sitemap.xml`, and `robots.txt` before copying only CA certificates, `/out/lambda-embed` (as `/lambda`), config, content, and generated XML/txt files into the final scratch image.
 - In `Dockerfile.debug`, the build stage produces `/out/lambda` and `/out/mdblog`, generates the same derived content artifacts, and copies all binaries, content, pages, templates, assets, config, and generated XML/txt files into the final image.
 
-## Publication Flow
+## Write → Commit → Publish Flow
 
-- The production publish path is GitHub Actions based rather than a runtime CMS upload flow.
-- A push to `master` that changes `posts/**/*.md` triggers `.github/workflows/ghcr-release.yml`.
+- The production publish path is GitHub Actions based rather than a runtime CMS upload flow. It follows the core philosophy of **Write → Commit → Publish**.
+- A push to `master` that changes `content/**/*.md` triggers `.github/workflows/ghcr-release.yml`.
 - That workflow builds the Docker image, computes version metadata from git, and pushes the resulting image to GHCR with tags including `latest`.
-- The Docker build itself regenerates `posts/posts.index.json`, `feed.xml`, `sitemap.xml`, and `robots.txt`, so Markdown post changes become part of the published image through that build stage.
+- The Docker build itself regenerates `content/content.index.json`, `feed.xml`, `sitemap.xml`, and `robots.txt`, so Markdown post changes become part of the published image through that build stage.
 - A second workflow, `.github/workflows/aws-deploy.yml`, listens for successful completion of the GHCR workflow, pulls the `latest` image from GHCR, retags and pushes it to Amazon ECR, and then runs `aws lambda update-function-code` to point the Lambda function at the new container image.
 - This means post Markdown files are published by being committed and pushed to `master`, not by being uploaded directly to the running server.
-- The automatic push trigger is scoped to `posts/**/*.md`; other Markdown locations such as `pages/` are not covered by that push-path filter and therefore do not use the same automatic publish trigger unless deployment is initiated through another path such as a release.
+- The automatic push trigger is scoped to `content/**/*.md`; other Markdown locations such as `pages/` are not covered by that push-path filter and therefore do not use the same automatic publish trigger unless deployment is initiated through another path such as a release.
 
 ## Content and Persistence Model
 
-- MDBlog has no database because its source of truth is the repository content itself: posts are Markdown files under `posts/`, standalone pages are Markdown files under `pages/`, and runtime settings live in `config.toml`.
-- Listing and search do not query a database; they read the pre-built `posts/posts.index.json` metadata file generated during the image build.
+- MDBlog has no database because its source of truth is the repository content itself: posts are Markdown files under `content/`, standalone pages are Markdown files under `pages/`, and runtime settings live in `config.toml`.
+- Listing and search do not query a database; they read the pre-built `content/content.index.json` metadata file generated during the image build.
 - Single post and page requests still read the corresponding Markdown file from disk inside the container and render it on demand.
 - RSS and SEO files are also pre-generated during the image build, then served as static runtime artifacts.
 - If the post index is missing or invalid, the blog can fall back to scanning Markdown files directly, which preserves correctness without introducing a database dependency.

--- a/wiki/repo-map.md
+++ b/wiki/repo-map.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MDBlog is a flat-file blog engine written in Go 1.24. It serves Markdown posts and standalone pages, generates a metadata index for listing and search, and can run locally or as an AWS Lambda container image.
+MDBlog is a flat-file blog engine written in Go 1.26. It serves Markdown posts and standalone pages, generates a metadata index for listing and search, and can run locally or as an AWS Lambda container image.
 
 ## High-Signal Areas
 

--- a/wiki/repo-map.md
+++ b/wiki/repo-map.md
@@ -97,7 +97,7 @@ MDBlog is a flat-file blog engine written in Go 1.24. It serves Markdown posts a
 
 ## Make Targets
 
-- Core development targets: `help`, `serve`, `build`, `build-embed`, `build-index`, `build-feed`, `build-sitemap`, `lint`, `lint-config`, `test`, `render`, `request`, and `new-post`.
+- Core development targets: `help`, `serve`, `build`, `build-embed`, `build-index`, `build-feed`, `build-sitemap`, `lint`, `lint-config`, `test`, `benchmark`, `render`, `request`, and `new-post`.
 - Wiki maintenance targets: `wiki-list`, `wiki-headings`, `wiki-log-tail`, `wiki-search`, `wiki-changed`, `wiki-candidates`, `wiki-lint`, and `wiki-refresh`. All targets delegate to the global `wiki-engine` CLI (`github.com/ramayac/go-wiki-engine`). Per-repo configuration lives in `.wikirc`. `wiki/` and `scripts/` are excluded from the Docker build via `.dockerignore`.
 - Docker targets: `docker-build`, `docker-build-debug`, `docker-run`, `docker-run-release`, `docker-stop`, `docker-push`, and `docker-pull`.
 - `help` is the default goal and prints the annotated target list from the Makefile.


### PR DESCRIPTION
This PR adds a separate benchmark script using ApacheBench (ab) and a corresponding Makefile target to easily measure HTTP throughput and latency of the compiled binary. It also upgrades the Go compiler version and refines the core publishing tagline.

### Key Additions:
1. **[scripts/benchmark.sh](scripts/benchmark.sh)**: Compiles the binary, runs a local server in the background, executes `ab` against the homepage and a post page, and terminates the server.
2. **`make benchmark`**: Makefile target to run the benchmark suite.
3. **Go 1.26 Upgrade**: Upgraded the project runtime dependency from Go 1.24 to Go 1.26 across [go.mod](go.mod), [Dockerfile](Dockerfile), [Dockerfile.debug](Dockerfile.debug), and all documentation. This enables the **Green Tea Garbage Collector** by default, reduces cgo overhead, improves stack allocation for slices, and speeds up small object memory allocation by up to 30% to optimize AWS Lambda cold starts and latency.
4. **Tagline & Doc updates**: Changed the core publishing tagline from "Write → Commit → Push → Deploy" to **"Write → Commit → Publish"** across [README.md](README.md), [wiki/agents.md](wiki/agents.md), and [wiki/repo-map.md](wiki/repo-map.md).
5. **Go 1.26 Benchmarks**: Ran the new benchmark targets under Go 1.26 (achieving **10,389 req/sec** on the homepage at **0.96ms** average latency, and **5,418 req/sec** on post pages at **1.84ms** average latency) and documented the results in [wiki/performance.md](wiki/performance.md).
